### PR TITLE
Remove the attributes feature, instead making it available regardless

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tabbycat"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["SchrodingerZhu <i@zhuyi.fan>"]
 edition = "2018"
 license = "MIT"
@@ -15,10 +15,3 @@ repository = "https://github.com/SchrodingerZhu/tabbycat"
 regex = "1"
 anyhow = "1"
 derive_builder = "0.9"
-
-[features]
-attributes = []
-
-[package.metadata.docs.rs]
-features = ["attributes"]
-

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -7,7 +7,7 @@
 //! To add other attributes, you can use an unsafe way to construct an identity pair.
 //! ```
 //! use tabbycat::Identity;
-//! let my_pair = (Identity::String("label".into()), Identity::Quoted("test"));
+//! let my_pair = (Identity::String("label".into()), Identity::Quoted(std::borrow::Cow::Borrowed("test")));
 //! ```
 //! (Most of the time the safe way (`Identity::id`) should be good, but as we didn't provide a type for something like the
 //! [`lblString`](https://graphviz.org/doc/info/attrs.html#k:lblString), you may want to add a unquoted string using the *unsafe* way.)

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -64,15 +64,10 @@ pub enum Identity<'a> {
     Float(f32),
     Double(f64),
     Quoted(Cow<'a, str>),
-    #[cfg(feature = "attributes")]
     ArrowName([Option<&'a str>; 4]),
-    #[cfg(feature = "attributes")]
     RGBA(u8, u8, u8, u8),
-    #[cfg(feature = "attributes")]
     HSV(f32, f32, f32),
-    #[cfg(feature = "attributes")]
     Point2D(f32, f32, bool),
-    #[cfg(feature = "attributes")]
     Point3D(f32, f32, f32, bool),
 }
 
@@ -434,15 +429,11 @@ impl<'a> std::fmt::Display for Identity<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         use Identity::*;
         match self {
-            #[cfg(feature = "attributes")]
             RGBA(r, g, b, a) => write!(f, "\"#{:x}{:x}{:x}{:x}\"", r, g, b, a),
-            #[cfg(feature = "attributes")]
             HSV(h, s, v) => write!(f, "\"{},+{},+{}\"", h, s, v),
-            #[cfg(feature = "attributes")]
             Point2D(x, y, fixed) => {
                 write!(f, "\"{},{}\"", x, y).and(if *fixed { write!(f, "!") } else { Ok(()) })
             }
-            #[cfg(feature = "attributes")]
             Point3D(x, y, z, fixed) => {
                 write!(f, "\"{},{},{}\"", x, y, z).and(if *fixed { write!(f, "!") } else { Ok(()) })
             }
@@ -463,7 +454,6 @@ impl<'a> std::fmt::Display for Identity<'a> {
             I128(id) => write!(f, "{}", id),
             U128(id) => write!(f, "{}", id),
             Bool(flag) => write!(f, "{}", flag),
-            #[cfg(feature = "attributes")]
             ArrowName(names) => names.iter().fold(Ok(()), |acc, x| {
                 acc.and(match x {
                     None => Ok(()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@
 //! The whole crate is implemented following the dot language specification listed at [graphviz's website](https://graphviz.org/doc/info/lang.html).
 //!
 //! # Attributes
-//! There is an optional feature `attributes` which implemented a subset of the [attributes list of the dot language](https://graphviz.org/doc/info/attrs.html).
-//! By enabling this feature, you will be able to write something like:
+//! This crate implements a subset of the [attributes list of the dot language](https://graphviz.org/doc/info/attrs.html).
+//! You can write something like:
 //!
 //! ```
 //! use tabbycat::attributes::*;
@@ -53,12 +53,10 @@ pub use graph::*;
 
 mod graph;
 
-#[cfg(feature = "attributes")]
 pub mod attributes;
 
 #[cfg(test)]
 mod test {
-    #[cfg(feature = "attributes")]
     use crate::attributes::*;
     use crate::Compass::NorthEast;
     use crate::Identity;
@@ -88,7 +86,7 @@ mod test {
         }
 
         {
-            let a = Port::ID(I::String("a"), None);
+            let a = Port::ID(I::String(std::borrow::Cow::Borrowed("a")), None);
             assert_eq!(":a", a.to_string())
         }
 
@@ -107,17 +105,12 @@ mod test {
             .add(I::id("color")?, I::id("red")?)
             .new_bracket()
             .add(I::id("size")?, I::from(12_isize));
-        #[cfg(feature = "attributes")]
             {
                 let attrlist = attrlist.add_pair(fontsize(12.0))
                     .add_pair(label("test"))
                     .add_pair(fillcolor(Color::Blue))
                     .add_pair(arrowhead(ArrowShape::Orinv));
                 Ok(assert_eq!("[name=abc;color=red;][size=12;fontsize=12;label=\"test\";fillcolor=blue;arrowhead=orinv;]", attrlist.to_string()))
-            }
-        #[cfg(not(feature = "attributes"))]
-            {
-                Ok(assert_eq!("[name=abc;color=red;][size=12;]", attrlist.to_string()))
             }
     }
 
@@ -126,12 +119,12 @@ mod test {
     fn codegen_subgraph() {
         use crate::{Stmt, StmtList, SubGraph, Identity, Port, Compass};
         let g = SubGraph::SubGraph {
-            id: Some(Identity::String("G")),
+            id: Some(Identity::String(std::borrow::Cow::Borrowed("G"))),
             stmts: Box::new(StmtList(
                 vec![Stmt::Node {
-                    id: Identity::String("g"),
+                    id: Identity::String(std::borrow::Cow::Borrowed("g")),
                     port: Some(Port::ID(
-                        Identity::String("h"),
+                        Identity::String(std::borrow::Cow::Borrowed("h")),
                         Some(Compass::SouthWest),
                     )),
                     attr: None,


### PR DESCRIPTION
Rationale: It seems like people will pretty commonly want to use attributes, which are a major feature of the dot language, and this overall crate is quite small, so it seemed fine to just include the whole thing and not worth the extra complexity of managing features. I was motivated to do this since I couldn't get the doc tests to pass with the feature remaining in place since their code wouldn't have the feature available.

Also fix tests that were failing:

```
cargo test
   Compiling tabbycat v0.1.3 (/Users/josh/repos/tabbycat)
    Finished test [unoptimized + debuginfo] target(s) in 0.98s
     Running unittests (target/debug/deps/tabbycat-b5243673c624f1b4)

running 7 tests
test test::codegen_subgraph ... ok
test test::codegen_port ... ok
test test::codegen_compass ... ok
test test::codegen_id ... ok
test test::codegen_attrlist ... ok
test test::codegen_edge ... ok
test test::codegen_graph ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

   Doc-tests tabbycat

running 3 tests
test src/attributes.rs - attributes (line 8) ... ok
test src/lib.rs - (line 13) ... ok
test src/lib.rs - (line 27) ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.43s
```