### PR TITLE
Add HTML string support

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -175,6 +175,7 @@ attribute_from!(z, f64);
 attribute_from!(bgcolor, Color);
 attribute_from!(color, Color);
 attribute_from!(fillcolor, Color);
+attribute_from!(fontcolor, Color);
 attribute_from!(labelfontcolor, Color);
 attribute_from!(pencolor, Color);
 attribute_from!(shape, Shape);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -63,6 +63,7 @@ pub enum Identity {
     Float(f32),
     Double(f64),
     Quoted(String),
+    Html(String),
     ArrowName([Option<String>; 4]),
     RGBA(u8, u8, u8, u8),
     HSV(f32, f32, f32),
@@ -417,7 +418,7 @@ impl std::fmt::Display for Identity {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         use Identity::*;
         match self {
-            RGBA(r, g, b, a) => write!(f, "\"#{:x}{:x}{:x}{:x}\"", r, g, b, a),
+            RGBA(r, g, b, a) => write!(f, "\"#{:0<2x}{:0<2x}{:0<2x}{:0<2x}\"", r, g, b, a),
             HSV(h, s, v) => write!(f, "\"{},+{},+{}\"", h, s, v),
             Point2D(x, y, fixed) => {
                 write!(f, "\"{},{}\"", x, y).and(if *fixed { write!(f, "!") } else { Ok(()) })
@@ -430,6 +431,7 @@ impl std::fmt::Display for Identity {
             Float(id) => write!(f, "{}", id),
             Double(id) => write!(f, "{}", id),
             Quoted(id) => write!(f, "{:?}", id),
+            Html(id) => write!(f, "< {} >", id),
             ISize(id) => write!(f, "{}", id),
             I8(id) => write!(f, "{}", id),
             U8(id) => write!(f, "{}", id),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -341,6 +341,13 @@ impl Identity {
     {
         Identity::String(data.into())
     }
+
+    pub fn html<S>(data: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Identity::Html(data.into())
+    }
 }
 
 impl Port {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,10 +140,15 @@ mod test {
             .arrow_to_node(Identity::id("b")?, None)
             .arrow_to_subgraph(SubGraph::cluster(
                 StmtList::new()
+                    .add_attr(
+                        crate::AttrType::Graph,
+                        crate::AttrList::new()
+                            .add(Identity::id("color")?, Identity::RGBA(0, 10, 254, 90)),
+                    )
                     .add_node(Identity::id("c")?, None, None)
                     .add_node(Identity::id("d")?, None, None),
             ));
-        assert_eq!("a->b->{c;d;}[color=pink;]", edge.to_string());
+        assert_eq!("a->b->{graph [color=\"#00a0fe5a\";];c;d;}[color=pink;]", edge.to_string());
         Ok(())
     }
 


### PR DESCRIPTION
See more info here: https://graphviz.org/doc/info/shapes.html#html

> If the value of a [label](https://graphviz.org/docs/attrs/label/) attribute (label for nodes, edges, clusters, and graphs, and the [headlabel](https://graphviz.org/docs/attrs/headlabel/) and [taillabel](https://graphviz.org/docs/attrs/taillabel/) attributes of an edge) is given as an [HTML string](https://graphviz.org/doc/info/lang.html#html), that is, delimited by <...> rather than "...", the label is interpreted as an HTML description. At their simplest, such labels can describe multiple lines of variously aligned text as provided by ordinary [string labels](https://graphviz.org/docs/attr-types/escString/). More generally, the label can specify a table similar to those provided by HTML, with different graphical attributes at each level.

Also:
* Fix RGBA code formatting (add zero padding) and add test coverage
* Add fontcolor attribute: https://graphviz.org/docs/attrs/fontcolor/

Tests still pass:

```
 $ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.04s
     Running unittests (target/debug/deps/tabbycat-b5243673c624f1b4)

running 7 tests
test test::codegen_compass ... ok
test test::codegen_port ... ok
test test::codegen_subgraph ... ok
test test::codegen_id ... ok
test test::codegen_attrlist ... ok
test test::codegen_graph ... ok
test test::codegen_edge ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

   Doc-tests tabbycat

running 3 tests
test src/attributes.rs - attributes (line 8) ... ok
test src/lib.rs - (line 13) ... ok
test src/lib.rs - (line 27) ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.64s
```